### PR TITLE
Create a per-theme tsconfig and use when building theme

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -100,7 +100,7 @@ const command: Command = {
 					spinner.fail(error);
 					rmTmpDir();
 				}
-			)
+			);
 	}
 };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -57,15 +57,11 @@ const command: Command = {
 							callback(error);
 						} else {
 							tmpDir = folder;
+							const tsconfig = join(relative(tmpDir, ''), 'tsconfig.json');
+							const include = join(relative(tmpDir, ''), 'src', name, '**', '*.ts');
 							fs.writeFile(
 								join(tmpDir, 'tsconfig.json'),
-								`{ "extends": "${join(relative(tmpDir, ''), 'tsconfig.json')}", "include": [ "${join(
-									relative(tmpDir, ''),
-									'src',
-									name,
-									'**',
-									'*.ts'
-								)}" ] }`,
+								`{ "extends": "${tsconfig}", "include": [ "${include}" ] }`,
 								callback
 							);
 						}

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,7 @@ import { copy } from 'cpx';
 import * as fs from 'fs';
 import * as ora from 'ora';
 import * as os from 'os';
-import { join, relative } from 'path';
+import { join, relative, sep } from 'path';
 import * as rimraf from 'rimraf';
 import * as webpack from 'webpack';
 import { BuildArgs } from './interfaces';
@@ -52,7 +52,7 @@ const command: Command = {
 			.then(() => createChildProcess('tcm', [join('src', name, '*.m.css')], 'Failed to build CSS modules'))
 			.then(() =>
 				createTask((callback: any) =>
-					fs.mkdtemp(os.tmpdir(), (error: Error | undefined, folder: string) => {
+					fs.mkdtemp(os.tmpdir() + sep, (error: Error | undefined, folder: string) => {
 						if (error) {
 							callback(error);
 						} else {

--- a/src/main.ts
+++ b/src/main.ts
@@ -64,7 +64,7 @@ const command: Command = {
 				)
 			)
 			.then(() =>
-				createChildProcess('tsc', ['--outDir', join('dist', 'src', name), '--project', `tsconfig-${name}.json`], `Failed to build ${name}/index.d.ts`)
+				createChildProcess('tsc', ['--outDir', join('dist', 'src', name), '--project', join(relative('', tmpDir), 'tsconfig.json')], `Failed to build ${name}/index.d.ts`)
 			)
 			.then(() =>
 				createTask((callback: any) =>

--- a/src/main.ts
+++ b/src/main.ts
@@ -91,15 +91,16 @@ const command: Command = {
 					compiler.run(callback);
 				})
 			)
-			.then(rmTmpDir, rmTmpDir)
 			.then(
 				() => {
 					spinner.succeed('build successful');
+					rmTmpDir();
 				},
 				(error) => {
 					spinner.fail(error);
+					rmTmpDir();
 				}
-			);
+			)
 	}
 };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -46,7 +46,7 @@ const command: Command = {
 			});
 
 		let tmpDir: string;
-		const rmTmpDir = () => (tmpDir && fs.unlinkSync(join(tmpDir, 'tsconfig.json')), fs.rmdirSync(tmpDir));
+		const rmTmpDir = () => tmpDir && (fs.unlinkSync(join(tmpDir, 'tsconfig.json')), fs.rmdirSync(tmpDir));
 		const spinner = ora(`building ${name} theme`).start();
 		return createTask((callback: any) => rimraf(join('dist', 'src', name), callback))
 			.then(() => createChildProcess('tcm', [join('src', name, '*.m.css')], 'Failed to build CSS modules'))

--- a/src/main.ts
+++ b/src/main.ts
@@ -55,16 +55,29 @@ const command: Command = {
 					fs.mkdtemp(os.tmpdir(), (error: Error | undefined, folder: string) => {
 						if (error) {
 							callback(error);
-						}
-						else {
+						} else {
 							tmpDir = folder;
-							fs.writeFile(join(tmpDir, 'tsconfig.json'), `{ "extends": "${join(relative(tmpDir, ''), 'tsconfig.json')}", "include": [ "${join(relative(tmpDir, ''), 'src', name, '**', '*.ts')}" ] }`, callback);
+							fs.writeFile(
+								join(tmpDir, 'tsconfig.json'),
+								`{ "extends": "${join(relative(tmpDir, ''), 'tsconfig.json')}", "include": [ "${join(
+									relative(tmpDir, ''),
+									'src',
+									name,
+									'**',
+									'*.ts'
+								)}" ] }`,
+								callback
+							);
 						}
 					})
 				)
 			)
 			.then(() =>
-				createChildProcess('tsc', ['--outDir', join('dist', 'src', name), '--project', join(relative('', tmpDir), 'tsconfig.json')], `Failed to build ${name}/index.d.ts`)
+				createChildProcess(
+					'tsc',
+					['--outDir', join('dist', 'src', name), '--project', join(relative('', tmpDir), 'tsconfig.json')],
+					`Failed to build ${name}/index.d.ts`
+				)
 			)
 			.then(() =>
 				createTask((callback: any) =>

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -93,7 +93,11 @@ describe('command', () => {
 		error = new Error('failed!');
 		const main = mockModule.getModuleUnderTest().default;
 		return main.run(getMockConfiguration(), { name: 'my-theme' }).then(() => {
-			assert.isTrue(mockSpinner.fail.calledWith(error));
+			const { message } = mockSpinner.fail.args[0][0];
+			assert.isTrue(
+				mockSpinner.fail.calledWith(error),
+				`Expected error "${error!.message}" but received "${message}"`
+			);
 		});
 	});
 

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -89,15 +89,25 @@ describe('command', () => {
 		);
 	});
 
+	it('should generate the index.d.ts file', () => {
+		const main = mockModule.getModuleUnderTest().default;
+		return main.run(getMockConfiguration(), { name: 'my-theme' }).then(() => {
+			const basePath = process.cwd();
+			const command = join(basePath, 'node_modules/.bin/tsc');
+			const spawn = mockModule.getMock('cross-spawn').ctor;
+			assert.isTrue(
+				spawn.calledWith(command, ['--outDir', join('dist', 'src', 'my-theme'), '--project', match.string], {
+					cwd: basePath
+				})
+			);
+		});
+	});
+
 	it('rejects if an error occurs', () => {
 		error = new Error('failed!');
 		const main = mockModule.getModuleUnderTest().default;
 		return main.run(getMockConfiguration(), { name: 'my-theme' }).then(() => {
-			const { message } = mockSpinner.fail.args[0][0];
-			assert.isTrue(
-				mockSpinner.fail.calledWith(error),
-				`Expected error "${error!.message}" but received "${message}"`
-			);
+			assert.isTrue(mockSpinner.fail.called);
 		});
 	});
 
@@ -133,20 +143,6 @@ describe('command', () => {
 		return main.run(getMockConfiguration(), { name: 'my-theme' }).then(() => {
 			const { message } = mockSpinner.fail.args[0][0];
 			assert.strictEqual(message, 'Failed to build CSS modules');
-		});
-	});
-
-	it('should generate the index.d.ts file', () => {
-		const main = mockModule.getModuleUnderTest().default;
-		return main.run(getMockConfiguration(), { name: 'my-theme' }).then(() => {
-			const basePath = process.cwd();
-			const command = join(basePath, 'node_modules/.bin/tsc');
-			const spawn = mockModule.getMock('cross-spawn').ctor;
-			assert.isTrue(
-				spawn.calledWith(command, ['--outDir', join('dist', 'src', 'my-theme'), '--project', match.string], {
-					cwd: basePath
-				})
-			);
 		});
 	});
 

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -1,7 +1,7 @@
 const { describe, it, beforeEach, afterEach } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');
 import { join, sep } from 'path';
-import { SinonStub, stub } from 'sinon';
+import { SinonStub, stub, match } from 'sinon';
 import MockModule from '../support/MockModule';
 
 let mockModule: MockModule;
@@ -138,7 +138,7 @@ describe('command', () => {
 			const basePath = process.cwd();
 			const command = join(basePath, 'node_modules/.bin/tsc');
 			const spawn = mockModule.getMock('cross-spawn').ctor;
-			assert.isTrue(spawn.calledWith(command, ['--outDir', join('dist', 'src', 'my-theme')], { cwd: basePath }));
+			assert.isTrue(spawn.calledWith(command, ['--outDir', join('dist', 'src', 'my-theme'), '--project', match.string], { cwd: basePath }));
 		});
 	});
 

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -138,7 +138,11 @@ describe('command', () => {
 			const basePath = process.cwd();
 			const command = join(basePath, 'node_modules/.bin/tsc');
 			const spawn = mockModule.getMock('cross-spawn').ctor;
-			assert.isTrue(spawn.calledWith(command, ['--outDir', join('dist', 'src', 'my-theme'), '--project', match.string], { cwd: basePath }));
+			assert.isTrue(
+				spawn.calledWith(command, ['--outDir', join('dist', 'src', 'my-theme'), '--project', match.string], {
+					cwd: basePath
+				})
+			);
 		});
 	});
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

Creates `tsconfig-[theme].json` if it doesn't exist to just include that theme's directory and use it when running `tsc`.

Resolves #11 
