### PR TITLE
add process logging on error

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -41,9 +41,9 @@ const command: Command = {
 		const createChildProcess = (command: string, args: string[], errorMessage: string) =>
 			new Promise((resolve, reject) => {
 				const child = spawn(join(basePath, 'node_modules', '.bin', command), args, { cwd: basePath });
-				const logs: (string | Buffer)[] = [];
-				child.stderr.on('data', (data) => console.log(data.toString()));
+				const logs: string[] = [];
 				child.stdout.on('data', (data) => logs.push(data.toString()));
+				child.stderr.on('data', (data) => console.error(data.toString()));
 				child.on('error', reject);
 				child.on('exit', (code) => {
 					if (code !== 0) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,8 +41,17 @@ const command: Command = {
 		const createChildProcess = (command: string, args: string[], errorMessage: string) =>
 			new Promise((resolve, reject) => {
 				const child = spawn(join(basePath, 'node_modules', '.bin', command), args, { cwd: basePath });
+				const logs: (string | Buffer)[] = [];
+				child.stderr.on('data', (data) => console.log(data.toString()));
+				child.stdout.on('data', (data) => logs.push(data.toString()));
 				child.on('error', reject);
-				child.on('exit', (code) => (code !== 0 ? reject(new Error(errorMessage)) : resolve()));
+				child.on('exit', (code) => {
+					if (code !== 0) {
+						logs.forEach(console.log);
+						reject(new Error(errorMessage));
+					}
+					resolve();
+				});
 			});
 
 		let tmpDir: string;

--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -43,7 +43,7 @@ const postcssImportConfig = {
 };
 
 const postcssPresetConfig = {
-	browsers: ['last 2 versions', 'ie >= 10'],
+	browserslist: ['last 2 versions', 'ie >= 10'],
 	insertBefore: {
 		'color-mod-function': colorToColorMod
 	},


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
When a child process (such as `tsc`) errors, this change will display that to the console. This gives visibility to errors that are preventing the build. In the case of TSC, this is hard to identify because we mess with the tsconfig.json to fix inconsistencies with using this with one vs two themes.

Resolves #10 

```bash
> dojo build theme -n dojo

✔ build successful

> @dojo/themes@5.0.1-pre build:material /Users/aciccarello/Documents/code/dojo/themes
> dojo build theme -n material

⠴ building material themesrc/material/index.ts(32,7): error TS2322: Type '"This should error"' is not assignable to type 'number'.
 0 [
  'src/material/index.ts(32,7): error TS2322: Type ' +
    `'"This should error"' is not assignable to type ` +
    "'number'.\n",
  `src/material/index.ts(33,7): error TS2322: Type '"This ` +
    `should error too"' is not assignable to type 'number'.\n`
]
src/material/index.ts(33,7): error TS2322: Type '"This should error too"' is not assignable to type 'number'.
 1 [
  'src/material/index.ts(32,7): error TS2322: Type ' +
    `'"This should error"' is not assignable to type ` +
    "'number'.\n",
  `src/material/index.ts(33,7): error TS2322: Type '"This ` +
    `should error too"' is not assignable to type 'number'.\n`
]
✖ Error: Failed to build material/index.d.ts
```