### PR TITLE
build css modules in subfolders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4089,7 +4089,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4107,11 +4108,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4124,15 +4127,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4235,7 +4241,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4245,6 +4252,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4257,17 +4265,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4284,6 +4295,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4356,7 +4368,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4366,6 +4379,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4441,7 +4455,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4471,6 +4486,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4488,6 +4504,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4526,11 +4543,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,7 +50,7 @@ const command: Command = {
 		const spinner = ora(`building ${name} theme`).start();
 		return createTask((callback: any) => rimraf(join('dist', 'src', name), callback))
 			.then(() =>
-				createChildProcess('tcm', ['-p=' + join('src', name, '*.m.css')], 'Failed to build CSS modules')
+				createChildProcess('tcm', ['-p=' + join('src', name, '**', '*.m.css')], 'Failed to build CSS modules')
 			)
 			.then(() =>
 				createTask((callback: any) =>

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -133,7 +133,9 @@ describe('command', () => {
 			const basePath = process.cwd();
 			const command = join(basePath, 'node_modules/.bin/tcm');
 			const spawn = mockModule.getMock('cross-spawn').ctor;
-			assert.isTrue(spawn.calledWith(command, ['-p=' + join('src', 'my-theme', '*.m.css')], { cwd: basePath }));
+			assert.isTrue(
+				spawn.calledWith(command, ['-p=' + join('src', 'my-theme', '**', '*.m.css')], { cwd: basePath })
+			);
 		});
 	});
 


### PR DESCRIPTION
**Type:** bug 

The following has been addressed in the PR:

* [ ] There is a related issue
* [X] All code has been formatted with [`prettier`](https://prettier.io/)
* [X] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
The CSS module build step only found `.m.css` files in the theme directory itself.  This change is to search all subdirectories for such files.


Resolves #???
