### PR TITLE
Make compatible with legacy

### DIFF
--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -37,7 +37,7 @@ export default function webpackConfigFactory(args: any): Configuration {
 	};
 
 	const emitAll = emitAllFactory({
-		legacy: false,
+		legacy: true,
 		inlineSourceMaps: false,
 		basePath: themesPath,
 		additionalAssets: themeVariablesFiles


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/)
* [ ] Unit or Functional tests are included in the PR

**Description:**

For compatibility with legacy builds should output `.js` theme index not `.mjs`
