### PR TITLE
Revert "remove variables support (#30)"

### DIFF
--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -21,6 +21,9 @@ export default function webpackConfigFactory(args: any): Configuration {
 	const themesPath = args.themePath ? path.join(basePath, args.themePath) : path.join(basePath, 'src', 'theme');
 	const outputPath = path.join(basePath, 'output', 'theme');
 	const themes: string[] = args.themes;
+	const themeVariablesFiles = themes.map((theme) => {
+		return path.join(themesPath, theme, 'variables.css');
+	});
 
 	const postcssPresetConfig = {
 		browsers: ['last 2 versions', 'ie >= 10'],
@@ -29,13 +32,15 @@ export default function webpackConfigFactory(args: any): Configuration {
 		},
 		autoprefixer: {
 			grid: true
-		}
+		},
+		importFrom: themeVariablesFiles
 	};
 
 	const emitAll = emitAllFactory({
 		legacy: true,
 		inlineSourceMaps: false,
-		basePath: themesPath
+		basePath: themesPath,
+		additionalAssets: themeVariablesFiles
 	});
 
 	const tsLoaderOptions = {


### PR DESCRIPTION
This reverts commit b74241976405a30963194e7b076fe09621d5d6a3.

**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Reverts the changes to dealing with variables for the time being as are not ready for it. Waiting on supporting changes from dojo/framework.