### PR TITLE
Support variant in custom element themes

### DIFF
--- a/src/template/theme-installer.js
+++ b/src/template/theme-installer.js
@@ -30,5 +30,27 @@ if (theme && typeof window !== 'undefined') {
 			}
 		});
 	}
+	if (!window.dojoce.variant) {
+		Object.defineProperty(window.dojoce, 'variant', {
+			set: function(value) {
+				value = value === '' ? 'noVariant' : value;
+				if (value === window.dojoce.variant) {
+					return;
+				}
+				if (
+					window.dojoce.themes[window.dojoce.theme] &&
+					window.dojoce.themes[window.dojoce.theme].variants &&
+					window.dojoce.themes[window.dojoce.theme].variants[value]
+				) {
+					window.dojoce._variant = value;
+					window.dispatchEvent(new CustomEvent('dojo-theme-set', {}));
+				}
+			},
+			get: function() {
+				return window.dojoce._variant;
+			}
+		});
+	}
 	window.dojoce.theme = THEME_NAME;
 }
+


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Support setting theme variants for custom elements