### PR TITLE
Fixing issue with loading multiple themes

### DIFF
--- a/src/template/theme-installer.js
+++ b/src/template/theme-installer.js
@@ -13,7 +13,7 @@ if (theme && typeof window !== 'undefined') {
 
 	window.dojoce.themes[THEME_NAME] = theme;
 
-	if (!window.dojoce.theme) {
+	if (!window.dojoce.hasOwnProperty('theme')) {
 		Object.defineProperty(window.dojoce, 'theme', {
 			set: function(value) {
 				value = value === '' ? 'noTheme' : value;
@@ -30,7 +30,7 @@ if (theme && typeof window !== 'undefined') {
 			}
 		});
 	}
-	if (!window.dojoce.variant) {
+	if (!window.dojoce.hasOwnProperty('variant')) {
 		Object.defineProperty(window.dojoce, 'variant', {
 			set: function(value) {
 				value = value === '' ? 'noVariant' : value;


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Fixing an issue where loading multiple themes would cause the `variant` property to be redefined (and thus error).
